### PR TITLE
Correct the assembled boundary blocks such that the multiplication is…

### DIFF
--- a/examples/w90/cnt/run.py
+++ b/examples/w90/cnt/run.py
@@ -2,16 +2,18 @@ from threadpoolctl import threadpool_limits  # isort: skip
 import os
 import time
 
+import numba
 import numpy as np
 from mpi4py.MPI import COMM_WORLD as comm
 
 from quatrex.core.quatrex_config import parse_config
 from quatrex.core.scba import SCBA
 
+numba.set_num_threads(1)
 PATH = os.path.dirname(__file__)
 
 if __name__ == "__main__":
-    with threadpool_limits(limits=1):
+    with threadpool_limits(limits=7):
         config = parse_config(f"{PATH}/config.toml")
         scba = SCBA(config)
         tic = time.perf_counter()

--- a/src/quatrex/coulomb_screening/utils.py
+++ b/src/quatrex/coulomb_screening/utils.py
@@ -186,3 +186,39 @@ def assemble_boundary_blocks(
         ),
         axis=1,
     )
+
+
+def special_obc_multiply(
+    boundary_system_matrix: DSBSparse, dsbs1: DSBSparse, dsb2: DSBSparse
+):
+    """Special case of multiply for calculating the boundary_system_matrix."""
+    # Left side
+    boundary_system_matrix.blocks[0, 0] -= (
+        dsbs1.blocks[0, 0] @ dsb2.blocks[0, 0]
+        + dsbs1.blocks[0, 1] @ dsb2.blocks[1, 0]
+        + dsbs1.blocks[1, 0] @ dsb2.blocks[0, 1]
+    )
+    boundary_system_matrix.blocks[0, 1] -= (
+        dsbs1.blocks[0, 0] @ dsb2.blocks[0, 1] + dsbs1.blocks[0, 1] @ dsb2.blocks[0, 0]
+    )
+    boundary_system_matrix.blocks[0, 2] -= dsbs1.blocks[0, 1] @ dsb2.blocks[0, 1]
+    boundary_system_matrix.blocks[1, 0] -= (
+        dsbs1.blocks[1, 0] @ dsb2.blocks[0, 0] + dsbs1.blocks[0, 0] @ dsb2.blocks[1, 0]
+    )
+    boundary_system_matrix.blocks[2, 0] -= dsbs1.blocks[1, 0] @ dsb2.blocks[1, 0]
+    # Right side
+    boundary_system_matrix.blocks[-1, -1] -= (
+        dsbs1.blocks[-1, -1] @ dsb2.blocks[-1, -1]
+        + dsbs1.blocks[-1, -2] @ dsb2.blocks[-2, -1]
+        + dsbs1.blocks[-2, -1] @ dsb2.blocks[-1, -2]
+    )
+    boundary_system_matrix.blocks[-1, -2] -= (
+        dsbs1.blocks[-1, -1] @ dsb2.blocks[-1, -2]
+        + dsbs1.blocks[-1, -2] @ dsb2.blocks[-1, -1]
+    )
+    boundary_system_matrix.blocks[-1, -3] -= dsbs1.blocks[-1, -2] @ dsb2.blocks[-1, -2]
+    boundary_system_matrix.blocks[-2, -1] -= (
+        dsbs1.blocks[-2, -1] @ dsb2.blocks[-1, -1]
+        + dsbs1.blocks[-1, -1] @ dsb2.blocks[-2, -1]
+    )
+    boundary_system_matrix.blocks[-3, -1] -= dsbs1.blocks[-2, -1] @ dsb2.blocks[-2, -1]


### PR DESCRIPTION
… handled properly. The assembled boundary blocks for the OBC calculations should not be taken directly from the system matrix, as that introduces blocks from further into the device of the polarizability in the OBC calculation. Instead the boundary blocks should be constructed from a specialized matrix multiplication.