### PR TITLE
Update code to accommodate different block change factors

### DIFF
--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -113,11 +113,17 @@ class CoulombScreeningSolver(SubsystemSolver):
             self.small_block_sizes,
         ):
             raise ValueError("Block sizes do not match Coulomb matrix.")
-        if len(self.small_block_sizes) % 3 != 0:
+        self.new_block_size_factor = 3
+        if len(self.small_block_sizes) % self.new_block_size_factor != 0:
             # Not implemented yet.
-            raise ValueError("Number of blocks must be divisible by 3.")
+            raise ValueError(
+                f"Number of blocks must be divisible by {self.new_block_size_factor}."
+            )
         self.block_sizes = (
-            self.small_block_sizes[: len(self.small_block_sizes) // 3] * 3
+            self.small_block_sizes[
+                : len(self.small_block_sizes) // self.new_block_size_factor
+            ]
+            * self.new_block_size_factor
         )
         # Check that the provided block sizes match the coulomb matrix.
         if self.small_block_sizes.sum() != self.coulomb_matrix_sparray.shape[0]:
@@ -417,6 +423,7 @@ class CoulombScreeningSolver(SubsystemSolver):
             self.obc_blocks_right["above"],
             self.obc_blocks_right["left"],
             self.system_matrix,
+            self.new_block_size_factor,
         )
         # Go back to normal block sizes.
         self._set_block_sizes(self.block_sizes)

--- a/src/quatrex/coulomb_screening/utils.py
+++ b/src/quatrex/coulomb_screening/utils.py
@@ -35,24 +35,27 @@ def assemble_boundary_blocks(
     """
     # TODO: Below is not fault-tolerant. Add checks.
     bs = diag_left.shape[1] // nbc
+    num_blocks = mat.block_sizes.size
     for i in range(nbc):
         for j in range(nbc):
             k = i - j
             diag_left[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
                 max(0, k), -min(0, k)
             ]
-            right[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
-                0, -k + nbc
-            ]
-            below[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
-                k + nbc, 0
-            ]
             diag_right[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
                 min(0, k) - 1, -max(0, k) - 1
             ]
-            above[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
-                k - nbc - 1, -1
-            ]
-            left[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
-                -1, -k - nbc - 1
-            ]
+            if -k + nbc < num_blocks:
+                right[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                    0, -k + nbc
+                ]
+                above[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                    k - nbc - 1, -1
+                ]
+            if k + nbc < num_blocks:
+                below[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                    k + nbc, 0
+                ]
+                left[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                    -1, -k - nbc - 1
+                ]

--- a/src/quatrex/coulomb_screening/utils.py
+++ b/src/quatrex/coulomb_screening/utils.py
@@ -8,181 +8,51 @@ def assemble_boundary_blocks(
     below: xp.ndarray,
     diag_right: xp.ndarray,
     above: xp.ndarray,
-    left: xp.array,
+    left: xp.ndarray,
     mat: "DSBSparse",
+    nbc: int,
 ) -> None:
-    """Assembles the boundary blocks from the smaller blocks of input Hamiltonian."""
-    diag_left[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[0, 0],
-                    mat.blocks[0, 1],
-                    mat.blocks[0, 2],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[1, 0],
-                    mat.blocks[0, 0],
-                    mat.blocks[0, 1],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[2, 0],
-                    mat.blocks[1, 0],
-                    mat.blocks[0, 0],
-                ),
-                axis=2,
-            ),
-        ),
-        axis=1,
-    )
-    right[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[0, 3],
-                    xp.zeros_like(mat.blocks[0, 3]),
-                    xp.zeros_like(mat.blocks[0, 3]),
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[0, 2],
-                    mat.blocks[0, 3],
-                    xp.zeros_like(mat.blocks[0, 2]),
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[0, 1],
-                    mat.blocks[0, 2],
-                    mat.blocks[0, 3],
-                ),
-                axis=2,
-            ),
-        ),
-        axis=1,
-    )
-    below[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[3, 0],
-                    xp.zeros_like(mat.blocks[3, 0]),
-                    xp.zeros_like(mat.blocks[3, 0]),
-                ),
-                axis=1,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[2, 0],
-                    mat.blocks[3, 0],
-                    xp.zeros_like(mat.blocks[2, 0]),
-                ),
-                axis=1,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[1, 0],
-                    mat.blocks[2, 0],
-                    mat.blocks[3, 0],
-                ),
-                axis=1,
-            ),
-        ),
-        axis=2,
-    )
-    diag_right[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[-1, -1],
-                    mat.blocks[-2, -1],
-                    mat.blocks[-3, -1],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[-1, -2],
-                    mat.blocks[-1, -1],
-                    mat.blocks[-2, -1],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[-1, -3],
-                    mat.blocks[-1, -2],
-                    mat.blocks[-1, -1],
-                ),
-                axis=2,
-            ),
-        ),
-        axis=1,
-    )
-    above[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[-4, -1],
-                    xp.zeros_like(mat.blocks[-4, -1]),
-                    xp.zeros_like(mat.blocks[-4, -1]),
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[-3, -1],
-                    mat.blocks[-4, -1],
-                    xp.zeros_like(mat.blocks[-3, -1]),
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    mat.blocks[-2, -1],
-                    mat.blocks[-3, -1],
-                    mat.blocks[-4, -1],
-                ),
-                axis=2,
-            ),
-        ),
-        axis=1,
-    )
-    left[:] = xp.concatenate(
-        (
-            xp.concatenate(
-                (
-                    mat.blocks[-1, -4],
-                    mat.blocks[-1, -3],
-                    mat.blocks[-1, -2],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    xp.zeros_like(mat.blocks[-1, -3]),
-                    mat.blocks[-1, -4],
-                    mat.blocks[-1, -3],
-                ),
-                axis=2,
-            ),
-            xp.concatenate(
-                (
-                    xp.zeros_like(mat.blocks[-1, -4]),
-                    xp.zeros_like(mat.blocks[-1, -4]),
-                    mat.blocks[-1, -4],
-                ),
-                axis=2,
-            ),
-        ),
-        axis=1,
-    )
+    """Assembles the boundary blocks from the smaller blocks of input Hamiltonian.
+
+    Parameters
+    ----------
+    diag_left : xp.ndarray
+        The diagonal left block.
+    right : xp.ndarray
+        The right block of the diagonal left block.
+    below : xp.ndarray
+        The below block of the diagonal left block.
+    diag_right : xp.ndarray
+        The diagonal right block.
+    above : xp.ndarray
+        The above block of the diagonal right block.
+    left : xp.ndarray
+        The left block of the diagonal right block.
+    mat : DSBSparse
+        The boundary system matrix.
+    nbc : int
+        The number of small blocks used for the boundary blocks.
+    """
+    # TODO: Below is not fault-tolerant. Add checks.
+    bs = diag_left.shape[1] // nbc
+    for i in range(nbc):
+        for j in range(nbc):
+            k = i - j
+            diag_left[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                max(0, k), -min(0, k)
+            ]
+            right[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                0, -k + nbc
+            ]
+            below[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                k + nbc, 0
+            ]
+            diag_right[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                min(0, k) - 1, -max(0, k) - 1
+            ]
+            above[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                k - nbc - 1, -1
+            ]
+            left[..., i * bs : (i + 1) * bs, j * bs : (j + 1) * bs] = mat.blocks[
+                -1, -k - nbc - 1
+            ]

--- a/tests/coulomb_screening/test_utils.py
+++ b/tests/coulomb_screening/test_utils.py
@@ -1,0 +1,94 @@
+import numpy as xp
+import pytest
+from qttools.datastructures.dsbcoo import DSBCOO
+from scipy import sparse
+
+from quatrex.coulomb_screening.utils import assemble_boundary_blocks
+
+
+def _create_coo(sizes) -> sparse.coo_matrix:
+    """Returns a random complex sparse array."""
+    size = int(xp.sum(sizes))
+    rng = xp.random.default_rng()
+    density = rng.uniform(low=0.1, high=0.3)
+    coo = sparse.random(size, size, density=density, format="coo").astype(xp.complex128)
+    coo.data += 1j * rng.uniform(size=coo.nnz)
+    return coo
+
+
+@pytest.mark.parametrize("block_sizes", [6 * [6], 4 * [10]])
+@pytest.mark.parametrize("nbc", [1, 2, 3])
+def test_assemble_boundary_blocks(block_sizes, nbc):
+    """Test the function `assemble_boundary_blocks`."""
+    block_sizes = xp.array(block_sizes)
+    num_blocks = block_sizes.size
+    coo = _create_coo(block_sizes)
+    global_stack_shape = (3,)
+    dsbcoo = DSBCOO.from_sparray(coo, block_sizes, global_stack_shape)
+    diag_left = xp.zeros(
+        global_stack_shape + (nbc * block_sizes[0], nbc * block_sizes[0]),
+        dtype=xp.complex128,
+    )
+    right = xp.zeros_like(diag_left)
+    below = xp.zeros_like(diag_left)
+    diag_right = xp.zeros(
+        global_stack_shape + (nbc * block_sizes[-1], nbc * block_sizes[-1]),
+        dtype=xp.complex128,
+    )
+    above = xp.zeros_like(diag_right)
+    left = xp.zeros_like(diag_right)
+    assemble_boundary_blocks(
+        diag_left, right, below, diag_right, above, left, dsbcoo, nbc
+    )
+    for i in range(nbc):
+        for j in range(nbc):
+            assert xp.allclose(
+                dsbcoo.blocks[max(i - j, 0), max(j - i, 0)],
+                diag_left[
+                    ...,
+                    i * block_sizes[0] : (i + 1) * block_sizes[0],
+                    j * block_sizes[0] : (j + 1) * block_sizes[0],
+                ],
+            )
+            assert xp.allclose(
+                dsbcoo.blocks[min(i - j, 0) - 1, min(j - i, 0) - 1],
+                diag_right[
+                    ...,
+                    i * block_sizes[-1] : (i + 1) * block_sizes[-1],
+                    j * block_sizes[-1] : (j + 1) * block_sizes[-1],
+                ],
+            )
+            if j - i + nbc < num_blocks:
+                assert xp.allclose(
+                    dsbcoo.blocks[0, j - i + nbc],
+                    right[
+                        ...,
+                        i * block_sizes[0] : (i + 1) * block_sizes[0],
+                        j * block_sizes[0] : (j + 1) * block_sizes[0],
+                    ],
+                )
+                assert xp.allclose(
+                    dsbcoo.blocks[-(j - i + nbc) - 1, -1],
+                    above[
+                        ...,
+                        i * block_sizes[-1] : (i + 1) * block_sizes[-1],
+                        j * block_sizes[-1] : (j + 1) * block_sizes[-1],
+                    ],
+                )
+            if i - j + nbc < num_blocks:
+                assert xp.allclose(
+                    dsbcoo.blocks[i - j + nbc, 0],
+                    below[
+                        ...,
+                        i * block_sizes[0] : (i + 1) * block_sizes[0],
+                        j * block_sizes[0] : (j + 1) * block_sizes[0],
+                    ],
+                )
+                assert xp.allclose(
+                    dsbcoo.blocks[-1, -(i - j + nbc) - 1],
+                    left[
+                        ...,
+                        i * block_sizes[-1] : (i + 1) * block_sizes[-1],
+                        j * block_sizes[-1] : (j + 1) * block_sizes[-1],
+                    ],
+                )


### PR DESCRIPTION
Changed the screened interaction solver and updated the assemble_boundary_blocks method to accommodate any number of block change factors (`nbc` in old quatrex).