### PR TITLE
Fix for issue #20

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,8 @@ jobs:
           output: both
 
       - name: Add Coverage PR Comment
+        permissions:
+          pull-requests: write
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,8 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,8 +34,6 @@ jobs:
           output: both
 
       - name: Add Coverage PR Comment
-        permissions:
-          pull-requests: write
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:

--- a/examples/cp2k/cnt/run.py
+++ b/examples/cp2k/cnt/run.py
@@ -12,7 +12,7 @@ PATH = os.path.dirname(__file__)
 
 if __name__ == "__main__":
     with threadpool_limits(limits=1):
-        config = parse_config(f"{PATH}/config.toml")
+        config = parse_config(os.path.join(PATH, "config.toml"))
         scba = SCBA(config)
         tic = time.perf_counter()
         scba.run()

--- a/examples/w90/cnt/config.toml
+++ b/examples/w90/cnt/config.toml
@@ -1,4 +1,4 @@
-simulation_dir = "/home/awinka/Python/new_quatrex/quatrex/examples/w90/cnt"
+simulation_dir = "."
 
 [scba]
 max_iterations = 2

--- a/examples/w90/cnt/run.py
+++ b/examples/w90/cnt/run.py
@@ -12,7 +12,7 @@ PATH = os.path.dirname(__file__)
 
 if __name__ == "__main__":
     with threadpool_limits(limits=1):
-        config = parse_config(f"{PATH}/config.toml")
+        config = parse_config(os.path.join(PATH, "config.toml"))
         scba = SCBA(config)
         tic = time.perf_counter()
         scba.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = ["Nano-TCAD", "Quantum Transport", "NEGF"]
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "qttools @ git+git://github.com/vincent-maillou/qttools/tree/dev/sandbox",
+    "qttools @ git+git://github.com/vincent-maillou/qttools@dev",
     "numpy>=1.23.2",
     "scipy",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = ["Nano-TCAD", "Quantum Transport", "NEGF"]
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "qttools @ git+git://github.com/vincent-maillou/qttools@dev",
+    "qttools@git+https://github.com/vincent-maillou/qttools.git@dev",
     "numpy>=1.23.2",
     "scipy",
     "matplotlib",

--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -1,5 +1,6 @@
-# Copyright 2023-2024 ETH Zurich and the QuaTrEx authors. All rights reserved.
+# Copyright 2023-2025 ETH Zurich and the QuaTrEx authors. All rights reserved.
 
+import os
 import tomllib
 from pathlib import Path
 from typing import Literal
@@ -214,5 +215,12 @@ def parse_config(config_file: Path) -> QuatrexConfig:
     """Reads the TOML config file."""
     with open(config_file, "rb") as f:
         config = tomllib.load(f)
+    
+    if 'simulation_dir' in config:
+        simulation_dir = config['simulation_dir']
+        if not os.path.isabs(simulation_dir):
+            parent_dir = os.path.dirname(os.path.abspath(config_file))
+            simulation_dir = Path(os.path.join(parent_dir, simulation_dir))
+            config['simulation_dir'] = simulation_dir
 
     return QuatrexConfig(**config)

--- a/tests/config/path_test.py
+++ b/tests/config/path_test.py
@@ -1,0 +1,22 @@
+# Copyright 2023-2025 ETH Zurich and the QuaTrEx authors. All rights reserved.
+
+import os
+import pytest
+from pathlib import Path
+from quatrex.core.quatrex_config import parse_config
+
+
+quatrex_folder = Path(os.path.dirname(__file__)).parent.parent
+
+@pytest.mark.parametrize("toml_filename", ["examples/w90/cnt/config.toml", "examples/cp2k/cnt/config.toml"])
+def test_simulation_path(toml_filename: str) -> None:
+    toml_file = quatrex_folder.joinpath(toml_filename)
+    print(toml_file)
+    config = parse_config(toml_file)
+    print(config.simulation_dir)
+    assert os.path.exists(config.simulation_dir)
+    assert config.simulation_dir == toml_file.parent
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
Fixes #20

The fix uses utility methods from `os.path` to detect whether `config['simulation_dir']` is a relative path and convert it to an absolute one.