### PR TITLE
Lesser/Greater specific energy grid (energy_x)

### DIFF
--- a/examples/w90/cnt/config.toml
+++ b/examples/w90/cnt/config.toml
@@ -2,38 +2,72 @@ simulation_dir = "."
 
 [scba]
 max_iterations = 2
-mixing_factor = 1.0
+mixing_factor = 0.5
 phonon = false
 coulomb_screening = true
 
 [electron]
+use_energy_x = false
 left_fermi_level = -3.9  # eV
 right_fermi_level = -3.9 # eV
-solver = "rgf"
-eta = 1e-5
+
+fermi_level = -3.9 # eV
+conduction_band_edge = -3.566382123573606 # eV
+valence_band_edge = -4.174109778287768    # eV
+
+band_edge_tracking = "eigenvalues"
+
+eta = 1e-8
+
+[electron.solver]
+algorithm = "rgf"
 
 [electron.obc]
-algorithm = "sancho-rubio" # "spectral"
+algorithm = "spectral"
 
 nevp_solver = "beyn"
-r_o = 10.0
-r_i = 0.9
-c_hat = 25
-num_quad_points = 26
+
+# By pure guesswork:
+num_ref_iterations = 2
+max_decay = 5
+min_decay = 1e-3
+r_o = 10
+r_i = 0.8
+m_0 = 32
+num_quad_points = 30
 
 [electron.obc.memoizer]
-enable = true
-num_ref_iterations = 4
-convergence_tol = 1e-2
+enable = false
+#enable = true
+#num_ref_iterations = 4
+#convergence_tol = 1e-2
 
 [coulomb_screening]
-solver = "rgf"
+
+interaction_cutoff = 8 # A
+
+[coulomb_screening.solver]
+algorithm = "rgf"
 
 [coulomb_screening.obc]
-algorithm = "sancho-rubio" # "spectral"
+algorithm = "spectral"
 block_sections = 1
+nevp_solver = "full"
+
+num_ref_iterations = 10
+max_decay = 14
+min_decay = 1e-4
+
+[coulomb_screening.obc.memoizer]
+enable = false
+
+[coulomb_screening.lyapunov]
+algorithm = "spectral"
+
+[coulomb_screening.lyapunov.memoizer]
+enable = false
 
 [phonon]
 model = "pseudo-scattering"
-phonon_energy = 40e-3         # eV
-deformation_potential = 75e-3 # eV
+phonon_energy = 1e-3         # eV
+deformation_potential = 5e-3 # eV

--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -149,6 +149,8 @@ class ElectronConfig(BaseModel):
     eta_obc: NonNegativeFloat = 0  # eV
     eta: NonNegativeFloat = 1e-12  # eV
 
+    use_energy_x: bool = False
+
     fermi_level: float | None = None
     conduction_band_edge: float | None = None
     valence_band_edge: float | None = None

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -371,6 +371,7 @@ class SCBA:
                 self.p_coulomb_screening = PCoulombScreening_X(
                     self.quatrex_config,
                     energies_lesser,
+                    number_of_overlap_energies,
                 )
                 coulomb_screening_energies_x = (
                     electron_energies_x - electron_energies_x[-1]

--- a/src/quatrex/coulomb_screening/__init__.py
+++ b/src/quatrex/coulomb_screening/__init__.py
@@ -1,6 +1,17 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the quatrex package.
 
-from quatrex.coulomb_screening.polarization import PCoulombScreening
-from quatrex.coulomb_screening.solver import CoulombScreeningSolver
+from quatrex.coulomb_screening.polarization import (
+    PCoulombScreening,
+    PCoulombScreening_X,
+)
+from quatrex.coulomb_screening.solver import (
+    CoulombScreeningSolver,
+    CoulombScreeningSolver_X,
+)
 
-__all__ = ["CoulombScreeningSolver", "PCoulombScreening"]
+__all__ = [
+    "CoulombScreeningSolver",
+    "CoulombScreeningSolver_X",
+    "PCoulombScreening",
+    "PCoulombScreening_X",
+]

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -549,3 +549,305 @@ class CoulombScreeningSolver(SubsystemSolver):
             if comm.rank == 0
             else None
         )
+
+
+# TODO: Maybe implement another abstract class that don't necessitates solve with lesser and greater
+class CoulombScreeningSolver_X(SubsystemSolver):
+    """Solves the dynamics of the screened Coulomb interaction.
+
+    Parameters
+    ----------
+    quatrex_config : QuatrexConfig
+        The quatrex simulation configuration.
+    compute_config : ComputeConfig
+        The compute configuration.
+    energies_x : NDArray
+        The energies at which to solve.
+
+    """
+
+    system = "coulomb_screening"
+
+    def __init__(
+        self,
+        quatrex_config: QuatrexConfig,
+        compute_config: ComputeConfig,
+        energies_x: NDArray,
+        sparsity_pattern: sparse.coo_matrix,
+    ) -> None:
+        """Initializes the solver."""
+        super().__init__(quatrex_config, compute_config, energies_x)
+
+        # Load the Coulomb matrix.
+        self.coulomb_matrix_sparray = distributed_load(
+            quatrex_config.input_dir / "coulomb_matrix.npz"
+        ).astype(xp.complex128)
+
+        # Load block sizes.
+        self.small_block_sizes = distributed_load(
+            quatrex_config.input_dir / "block_sizes.npy"
+        ).astype(xp.int32)
+        if not check_block_sizes(
+            self.coulomb_matrix_sparray.row,
+            self.coulomb_matrix_sparray.col,
+            self.small_block_sizes,
+        ):
+            raise ValueError("Block sizes do not match Coulomb matrix.")
+        self.new_block_size_factor = 3
+        if len(self.small_block_sizes) % self.new_block_size_factor != 0:
+            # Not implemented yet.
+            raise ValueError(
+                f"Number of blocks must be divisible by {self.new_block_size_factor}."
+            )
+        self.block_sizes = (
+            self.small_block_sizes[
+                : len(self.small_block_sizes) // self.new_block_size_factor
+            ]
+            * self.new_block_size_factor
+        )
+        # Check that the provided block sizes match the coulomb matrix.
+        if self.small_block_sizes.sum() != self.coulomb_matrix_sparray.shape[0]:
+            raise ValueError(
+                "Block sizes do not match Coulomb matrix. "
+                f"{self.small_block_sizes.sum()} != {self.coulomb_matrix_sparray.shape[0]}"
+            )
+        # Create DBSparse matrix from the Coulomb matrix.
+        # TODO: Waste of memory. Not an energy-dependent matrix.
+        self.coulomb_matrix = compute_config.dsbsparse_type.from_sparray(
+            sparsity_pattern.astype(xp.complex128),
+            block_sizes=self.small_block_sizes,
+            global_stack_shape=self.energies.shape,
+        )
+        self.coulomb_matrix.data = 0.0
+        self.coulomb_matrix += self.coulomb_matrix_sparray
+
+        sparsity_pattern = sparsity_pattern.tocsr()
+
+        v_times_p_sparsity_pattern = sparsity_pattern @ sparsity_pattern
+        # Allocate memory for the Coulomb matrix times polarization.
+        self.v_times_p_retarded = compute_config.dsbsparse_type.from_sparray(
+            v_times_p_sparsity_pattern.astype(xp.complex128),
+            block_sizes=self.block_sizes,
+            global_stack_shape=self.energies.shape,
+            densify_blocks=[(0, 0), (-1, -1)],  # Densify for OBC.
+        )
+
+        l_sparsity_pattern = v_times_p_sparsity_pattern @ sparsity_pattern
+        # Allocate memory for the L_lesser and L_greater matrices.
+        self.l_lesser = compute_config.dsbsparse_type.from_sparray(
+            l_sparsity_pattern.astype(xp.complex128),
+            block_sizes=self.block_sizes,
+            global_stack_shape=self.energies.shape,
+            densify_blocks=[(0, 0), (-1, -1)],  # Densify for OBC.
+        )
+        self.system_matrix = compute_config.dsbsparse_type.zeros_like(
+            self.v_times_p_retarded
+        )
+
+        # Boundary conditions.
+        self.left_occupancies = bose_einstein(
+            self.local_energies,
+            quatrex_config.coulomb_screening.temperature,
+        )
+        self.right_occupancies = bose_einstein(
+            self.local_energies,
+            quatrex_config.coulomb_screening.temperature,
+        )
+        # Allocate memory for the OBC blocks.
+        self.obc_blocks_left = {}
+        self.obc_blocks_right = {}
+        self.obc_blocks_left["diag"] = xp.zeros_like(self.system_matrix.blocks[0, 0])
+        self.obc_blocks_left["right"] = xp.zeros_like(
+            self.obc_blocks_left["diag"],
+        )
+        self.obc_blocks_left["below"] = xp.zeros_like(
+            self.obc_blocks_left["diag"],
+        )
+        self.obc_blocks_right["diag"] = xp.zeros_like(self.system_matrix.blocks[-1, -1])
+        self.obc_blocks_right["above"] = xp.zeros_like(
+            self.obc_blocks_right["diag"],
+        )
+        self.obc_blocks_right["left"] = xp.zeros_like(
+            self.obc_blocks_right["diag"],
+        )
+
+    def _set_block_sizes_x(self, block_sizes: NDArray) -> None:
+        """Sets the block sizes of all matrices.
+
+        Parameters
+        ----------
+        block_sizes : NDArray
+            The new block sizes.
+
+        """
+        self.v_times_p_retarded.block_sizes = block_sizes
+        self.system_matrix.block_sizes = block_sizes
+        self.l_lesser.block_sizes = block_sizes
+
+    def _apply_obc_x(self, l_lesser: DSBSparse) -> None:
+        """Applies open boundary conditions.
+
+        Parameters
+        ----------
+        l_lesser : DSBSparse
+            The lesser quasi self-energy.
+
+        """
+
+        # Compute surface Green's functions.
+        x_00 = self.obc(
+            self.obc_blocks_left["diag"],
+            self.obc_blocks_left["right"],
+            self.obc_blocks_left["below"],
+            "left",
+        )
+        x_nn = self.obc(
+            self.obc_blocks_right["diag"],
+            self.obc_blocks_right["left"],
+            self.obc_blocks_right["above"],
+            "right",
+        )
+
+        # Apply the retarded boundary self-energy.
+        self.system_matrix.blocks[0, 0] -= (
+            self.system_matrix.blocks[1, 0] @ x_00 @ self.system_matrix.blocks[0, 1]
+        )
+        self.system_matrix.blocks[-1, -1] -= (
+            self.system_matrix.blocks[-2, -1] @ x_nn @ self.system_matrix.blocks[-1, -2]
+        )
+
+        # Compute and apply the lesser boundary self-energy.
+        a_00 = self.obc_blocks_left["below"] @ x_00 @ self.l_lesser.blocks[0, 1]
+        a_nn = self.obc_blocks_right["above"] @ x_nn @ self.l_lesser.blocks[-1, -2]
+        w_00 = self.lyapunov(
+            x_00 @ self.obc_blocks_left["below"],
+            x_00
+            @ (l_lesser.blocks[0, 0] - (a_00 - a_00.conj().swapaxes(-1, -2)))
+            @ x_00.conj().swapaxes(-1, -2),
+            "left",
+        )
+        w_nn = self.lyapunov(
+            x_nn @ self.obc_blocks_right["above"],
+            x_nn
+            @ (l_lesser.blocks[-1, -1] - (a_nn - a_nn.conj().swapaxes(-1, -2)))
+            @ x_nn.conj().swapaxes(-1, -2),
+            "right",
+        )
+
+        l_lesser.blocks[0, 0] += self.system_matrix.blocks[
+            1, 0
+        ] @ w_00 @ self.system_matrix.blocks[1, 0].conj().swapaxes(-1, -2) - (
+            a_00 - a_00.conj().swapaxes(-1, -2)
+        )
+        l_lesser.blocks[-1, -1] += self.system_matrix.blocks[
+            -2, -1
+        ] @ w_nn @ self.system_matrix.blocks[-2, -1].conj().swapaxes(-1, -2) - (
+            a_nn - a_nn.conj().swapaxes(-1, -2)
+        )
+
+    def _assemble_system_matrix(self, v_times_p_retarded: DSBSparse) -> None:
+        """Assembles the system matrix."""
+        self.system_matrix.data = 0.0
+        self.system_matrix += sparse.eye(self.system_matrix.shape[-1])
+        self.system_matrix -= v_times_p_retarded
+
+    def solve(
+        self,
+        p_lesser: DSBSparse,
+        p_stupid: DSBSparse,
+        p_retarded: DSBSparse,
+        out: tuple[DSBSparse, ...],
+    ) -> None:
+        """Solves for the screened Coulomb interaction.
+
+        Parameters
+        ----------
+        p_lesser : DSBSparse
+            The lesser polarization.
+        p_retarded : DSBSparse
+            The retarded polarization.
+        out : tuple[DSBSparse, ...]
+            The output matrices. The order is (lesser, retarded).
+
+        """
+        times = []
+
+        # Compute the product of the Coulomb matrix with the polarization.
+        times.append(time.perf_counter())
+        # Change the block sizes to match the Coulomb matrix.
+        self._set_block_sizes_x(self.small_block_sizes)
+
+        btd_matmul(
+            self.coulomb_matrix,
+            p_retarded,
+            out=self.v_times_p_retarded,
+            spillover_correction=True,
+        )
+        btd_sandwich(
+            self.coulomb_matrix,
+            p_lesser,
+            out=self.l_lesser,
+            spillover_correction=True,
+        )
+
+        t_obc_multiply = time.perf_counter() - times.pop()
+
+        # Assemble the matrices.
+        times.append(time.perf_counter())
+        # Assemble the system matrix.
+        self._assemble_system_matrix(self.v_times_p_retarded)
+        # Assemble the boundary blocks.
+        assemble_boundary_blocks(
+            self.obc_blocks_left["diag"],
+            self.obc_blocks_left["right"],
+            self.obc_blocks_left["below"],
+            self.obc_blocks_right["diag"],
+            self.obc_blocks_right["above"],
+            self.obc_blocks_right["left"],
+            self.system_matrix,
+            self.new_block_size_factor,
+        )
+        # Go back to normal block sizes.
+        self._set_block_sizes_x(self.block_sizes)
+        t_assemble = time.perf_counter() - times.pop()
+
+        # Apply the OBC algorithm.
+        times.append(time.perf_counter())
+        self._apply_obc_x(self.l_lesser)
+        t_obc = time.perf_counter() - times.pop()
+
+        # Solve the system
+        times.append(time.perf_counter())
+        # TODO: Implement solve_x
+        # self.solver.selected_solve_x(
+        #     a=self.system_matrix,
+        #     sigma_lesser=self.l_lesser,
+        #     out=out,
+        #     return_retarded=True,
+        # )
+        self.solver.selected_solve(
+            a=self.system_matrix,
+            sigma_lesser=self.l_lesser,
+            sigma_greater=self.l_lesser,
+            out=(out[0], out[0], out[1]),
+            return_retarded=True,
+        )
+        t_solve = time.perf_counter() - times.pop()
+
+        # Compute the retarded Screened interaction (mainly used for debugging).
+        # Currently doesn't work.
+        # obc_multiply(out[2], (out[2], self.coulomb_matrix), self.block_sizes)
+
+        w_lesser, _ = out
+        w_lesser.data = 0.5 * (
+            w_lesser.data - w_lesser.ltranspose(copy=True).data.conj()
+        )
+
+        (
+            print(
+                f"OBC Multiply: {t_obc_multiply}, Assemble: {t_assemble}, OBC: {t_obc}, Solve: {t_solve}",
+                flush=True,
+            )
+            if comm.rank == 0
+            else None
+        )

--- a/src/quatrex/electron/__init__.py
+++ b/src/quatrex/electron/__init__.py
@@ -1,14 +1,22 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the quatrex package.
 
-from quatrex.electron.solver import ElectronSolver
-from quatrex.electron.sse_coulomb_screening import SigmaCoulombScreening, SigmaFock
+from quatrex.electron.solver import ElectronSolver, ElectronSolver_X
+from quatrex.electron.sse_coulomb_screening import (
+    SigmaCoulombScreening,
+    SigmaCoulombScreening_X,
+    SigmaFock,
+    SigmaFock_X,
+)
 from quatrex.electron.sse_phonon import SigmaPhonon
 from quatrex.electron.sse_photon import SigmaPhoton
 
 __all__ = [
     "ElectronSolver",
+    "ElectronSolver_X",
     "SigmaPhonon",
     "SigmaPhoton",
     "SigmaFock",
+    "SigmaFock_X",
     "SigmaCoulombScreening",
+    "SigmaCoulombScreening_X",
 ]

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -5,7 +5,7 @@ import time
 from mpi4py.MPI import COMM_WORLD as comm
 from qttools import NDArray, sparse, xp
 from qttools.datastructures import DSBSparse
-from qttools.utils.mpi_utils import distributed_load
+from qttools.utils.mpi_utils import distributed_load, get_local_slice
 from qttools.utils.stack_utils import scale_stack
 
 from quatrex.bandstructure.band_edges import (
@@ -508,6 +508,552 @@ class ElectronSolver(SubsystemSolver):
         g_greater.data = 0.5 * (
             g_greater.data - g_greater.ltranspose(copy=True).data.conj()
         )
+
+        self._filter_peaks(out)
+
+        if self.band_edge_tracking == "dos-peaks":
+            s_00 = self._get_block(self.overlap_sparray, (0, 0))
+            s_nn = self._get_block(self.overlap_sparray, (-1, -1))
+            g_00 = g_retarded.blocks[0, 0]
+            g_nn = g_retarded.blocks[-1, -1]
+
+            local_left_dos = -xp.mean(
+                xp.diagonal(g_00 @ s_00, axis1=-2, axis2=-1).imag, axis=-1
+            )
+            local_right_dos = -xp.mean(
+                xp.diagonal(g_nn @ s_nn, axis1=-2, axis2=-1).imag, axis=-1
+            )
+            left_dos = xp.hstack(comm.allgather(local_left_dos)) / (2 * xp.pi)
+            right_dos = xp.hstack(comm.allgather(local_right_dos)) / (2 * xp.pi)
+
+            e_0_left = find_dos_peaks(left_dos, self.energies)
+            e_0_right = find_dos_peaks(right_dos, self.energies)
+
+            self._update_fermi_levels(e_0_left, e_0_right)
+
+        (
+            print(
+                f"Assemble: {t_assemble}, OBC: {t_obc}, Solve: {t_solve}",
+                flush=True,
+            )
+            if comm.rank == 0
+            else None
+        )
+
+
+class ElectronSolver_X(SubsystemSolver):
+    """Solves the electron dynamics.
+
+    Parameters
+    ----------
+    quatrex_config : QuatrexConfig
+        The quatrex simulation configuration.
+    compute_config : ComputeConfig
+        The compute configuration.
+    energies : np.ndarray
+        The energies at which to solve.
+
+    """
+
+    system = "electron"
+
+    def __init__(
+        self,
+        quatrex_config: QuatrexConfig,
+        compute_config: ComputeConfig,
+        energies: NDArray,
+        energies_lesser: NDArray,
+        energies_greater: NDArray,
+        number_of_overlap_energies: int,
+        sparsity_pattern: sparse.coo_matrix,
+    ) -> None:
+        """Initializes the electron solver."""
+        super().__init__(quatrex_config, compute_config, energies)
+
+        # Load the device Hamiltonian.
+        self.hamiltonian_sparray = distributed_load(
+            quatrex_config.input_dir / "hamiltonian.npz"
+        ).astype(xp.complex128)
+        self.block_sizes = distributed_load(
+            quatrex_config.input_dir / "block_sizes.npy"
+        )
+        self.block_offsets = xp.hstack(([0], xp.cumsum(self.block_sizes)))
+        # Check that the provided block sizes match the Hamiltonian.
+        if self.block_sizes.sum() != self.hamiltonian_sparray.shape[0]:
+            raise ValueError(
+                "Block sizes do not match Hamiltonian. "
+                f"{self.block_sizes.sum()} != {self.hamiltonian_sparray.shape[0]}"
+            )
+        # Load the overlap matrix.
+        try:
+            self.overlap_sparray = distributed_load(
+                quatrex_config.input_dir / "overlap.npz"
+            ).astype(xp.complex128)
+        except FileNotFoundError:
+            # No overlap provided. Assume orthonormal basis.
+            self.overlap_sparray = sparse.eye(
+                self.hamiltonian_sparray.shape[0],
+                format="coo",
+                dtype=self.hamiltonian_sparray.dtype,
+            )
+
+        self.overlap_sparray = self.overlap_sparray.tocoo()
+        # Check that the overlap matrix and Hamiltonian matrix match.
+        if self.overlap_sparray.shape != self.hamiltonian_sparray.shape:
+            raise ValueError(
+                "Overlap matrix and Hamiltonian matrix have different shapes."
+            )
+
+        # Load the potential.
+        try:
+            self.potential = distributed_load(
+                quatrex_config.input_dir / "potential.npy"
+            )
+            if self.potential.size != self.hamiltonian_sparray.shape[0]:
+                raise ValueError(
+                    "Potential matrix and Hamiltonian have different shapes."
+                )
+        except FileNotFoundError:
+            # No potential provided. Assume zero potential.
+            self.potential = xp.zeros(
+                self.hamiltonian_sparray.shape[0], dtype=self.hamiltonian_sparray.dtype
+            )
+
+        # Contacts.
+        self.flatband = quatrex_config.electron.flatband
+        self.eta_obc = quatrex_config.electron.eta_obc
+
+        # Band edges and Fermi levels.
+        # TODO: This only works for small potential variations accross
+        # the device.
+        # TODO: During this initialization we should compute the contact
+        # band structures and extract the correct fermi levels & band
+        # edges from there.
+        self.band_edge_tracking = quatrex_config.electron.band_edge_tracking
+        self.delta_fermi_level_conduction_band = (
+            quatrex_config.electron.conduction_band_edge
+            - quatrex_config.electron.fermi_level
+        )
+        self.left_mid_gap_energy = quatrex_config.electron.left_fermi_level
+        self.right_mid_gap_energy = quatrex_config.electron.right_fermi_level
+
+        self.temperature = quatrex_config.electron.temperature
+
+        self.left_fermi_level = quatrex_config.electron.left_fermi_level
+        self.right_fermi_level = quatrex_config.electron.right_fermi_level
+
+        # Generate energy grid for _x quantity.
+        self.energies_lesser = energies_lesser
+        self.energies_greater = energies_greater
+        energies_x = xp.concatenate((self.energies_lesser, self.energies_greater))
+        local_energies_x = get_local_slice(energies_x)
+        self.number_of_overlap_energies = number_of_overlap_energies
+
+        # Construct the bare system matrix.
+        self.bare_system_matrix = compute_config.dsbsparse_type.from_sparray(
+            sparsity_pattern.astype(xp.complex128),
+            block_sizes=self.block_sizes,
+            global_stack_shape=energies_x.shape,
+            densify_blocks=[(0, 0), (-1, -1)],  # Densify for OBC.
+        )
+        self.bare_system_matrix.data = 0.0
+
+        self.bare_system_matrix += self.overlap_sparray
+        scale_stack(
+            self.bare_system_matrix.data,
+            local_energies_x + 1j * quatrex_config.electron.eta,
+        )
+        self.bare_system_matrix -= self.hamiltonian_sparray
+        self.bare_system_matrix -= sparse.diags(self.potential)
+
+        self.system_matrix = compute_config.dsbsparse_type.zeros_like(
+            self.bare_system_matrix
+        )
+
+        left_occupancies = xp.concatenate(
+            (
+                fermi_dirac(
+                    self.energies_lesser - self.left_fermi_level, self.temperature
+                ),
+                1
+                - fermi_dirac(
+                    self.energies_greater - self.left_fermi_level, self.temperature
+                ),
+            )
+        )
+        self.left_occupancies = get_local_slice(left_occupancies)
+        right_occupancies = xp.concatenate(
+            (
+                fermi_dirac(
+                    self.energies_lesser - self.right_fermi_level, self.temperature
+                ),
+                1
+                - fermi_dirac(
+                    self.energies_greater - self.right_fermi_level, self.temperature
+                ),
+            )
+        )
+        self.right_occupancies = get_local_slice(right_occupancies)
+
+        # Allocate memory for the OBC blocks.
+        self.obc_blocks_retarded_left = xp.zeros_like(
+            self.bare_system_matrix.blocks[0, 0]
+        )
+        self.obc_blocks_retarded_right = xp.zeros_like(
+            self.bare_system_matrix.blocks[-1, -1]
+        )
+        self.obc_blocks_x_left = xp.zeros_like(self.bare_system_matrix.blocks[0, 0])
+        self.obc_blocks_x_right = xp.zeros_like(self.bare_system_matrix.blocks[-1, -1])
+
+        self.i_left = None
+        self.i_right = None
+
+    def update_potential(self, new_potential: NDArray) -> None:
+        """Updates the potential matrix.
+
+        Parameters
+        ----------
+        new_potential : NDArray
+            The new potential matrix.
+
+        """
+        potential_diff_matrix = sparse.diags(new_potential - self.potential)
+        self.bare_system_matrix -= potential_diff_matrix
+        self.potential = new_potential
+
+    def _update_fermi_levels(self, e_0_left: NDArray, e_0_right: NDArray) -> None:
+        """Updates the Fermi levels.
+
+        Parameters
+        ----------
+        out : tuple[DSBSparse, ...]
+            The Green's function tuple. In the order (lesser, greater,
+            retarded).
+
+        """
+        left_band_edges = find_band_edges(e_0_left, self.left_mid_gap_energy)
+        right_band_edges = find_band_edges(e_0_right, self.right_mid_gap_energy)
+
+        self.left_mid_gap_energy = xp.mean(left_band_edges)
+        self.right_mid_gap_energy = xp.mean(right_band_edges)
+
+        __, left_conduction_band_edge = left_band_edges
+        __, right_conduction_band_edge = right_band_edges
+
+        (
+            print(
+                f"Updating conduction band edges: "
+                f"{left_conduction_band_edge}, {right_conduction_band_edge}",
+                flush=True,
+            )
+            if comm.rank == 0
+            else None
+        )
+
+        self.left_fermi_level = (
+            left_conduction_band_edge - self.delta_fermi_level_conduction_band
+        )
+        self.right_fermi_level = (
+            right_conduction_band_edge - self.delta_fermi_level_conduction_band
+        )
+
+        self.left_occupancies = xp.concatenate(
+            (
+                fermi_dirac(
+                    self.energies_lesser - self.left_fermi_level, self.temperature
+                ),
+                1
+                - fermi_dirac(
+                    self.energies_greater - self.left_fermi_level, self.temperature
+                ),
+            )
+        )
+        self.right_occupancies = xp.concatenate(
+            (
+                fermi_dirac(
+                    self.energies_lesser - self.right_fermi_level, self.temperature
+                ),
+                1
+                - fermi_dirac(
+                    self.energies_greater - self.right_fermi_level, self.temperature
+                ),
+            )
+        )
+
+    def _get_block(self, coo: sparse.coo_matrix, index: tuple) -> NDArray:
+        """Gets a block from a COO matrix."""
+        row, col = index
+        row = row + len(self.block_sizes) if row < 0 else row
+        col = col + len(self.block_sizes) if col < 0 else col
+        mask = (
+            (self.block_offsets[row] <= coo.row)
+            & (coo.row < self.block_offsets[row + 1])
+            & (self.block_offsets[col] <= coo.col)
+            & (coo.col < self.block_offsets[col + 1])
+        )
+        block = xp.zeros(
+            (int(self.block_sizes[row]), int(self.block_sizes[col])), dtype=coo.dtype
+        )
+        block[
+            coo.row[mask] - self.block_offsets[row],
+            coo.col[mask] - self.block_offsets[col],
+        ] = coo.data[mask]
+
+        return block
+
+    def _apply_obc_x(self, sse_x: DSBSparse, sse_retarded: DSBSparse) -> None:
+        """Applies open boundary conditions.
+
+        Parameters
+        ----------
+        sse_x : DSBSparse
+            Combined lesser and greater scattering self-energy.
+        sse_retarded : DSBSparse
+            The retarded scattering self-energy.
+
+        """
+
+        # Extract the overlap matrix blocks.
+        s_00 = self._get_block(self.overlap_sparray, (0, 0))
+        s_01 = self._get_block(self.overlap_sparray, (0, 1))
+        s_10 = self._get_block(self.overlap_sparray, (1, 0))
+        s_nn = self._get_block(self.overlap_sparray, (-1, -1))
+        s_nm = self._get_block(self.overlap_sparray, (-1, -2))
+        s_mn = self._get_block(self.overlap_sparray, (-2, -1))
+
+        # Compute surface Green's functions.
+        g_00 = self.obc(
+            self.system_matrix.blocks[0, 0] + 1j * self.eta_obc * s_00,
+            self.system_matrix.blocks[0, 1] + 1j * self.eta_obc * s_01,
+            self.system_matrix.blocks[1, 0] + 1j * self.eta_obc * s_10,
+            "left",
+        )
+        g_nn = self.obc(
+            self.system_matrix.blocks[-1, -1] + 1j * self.eta_obc * s_nn,
+            self.system_matrix.blocks[-1, -2] + 1j * self.eta_obc * s_nm,
+            self.system_matrix.blocks[-2, -1] + 1j * self.eta_obc * s_mn,
+            "right",
+        )
+
+        # NOTE: Here we could possibly do peak/discontinuity detection
+        # on the surface Green's function DOS.
+
+        # Apply the retarded boundary self-energy.
+        sigma_00 = (
+            self.system_matrix.blocks[1, 0] @ g_00 @ self.system_matrix.blocks[0, 1]
+        )
+        sigma_nn = (
+            self.system_matrix.blocks[-2, -1] @ g_nn @ self.system_matrix.blocks[-1, -2]
+        )
+        self.system_matrix.blocks[0, 0] -= sigma_00
+        self.system_matrix.blocks[-1, -1] -= sigma_nn
+
+        gamma_00 = 1j * (sigma_00 - sigma_00.conj().swapaxes(-2, -1))
+        gamma_nn = 1j * (sigma_nn - sigma_nn.conj().swapaxes(-2, -1))
+
+        # Compute and apply the lesser boundary self-energy.
+        sse_x.blocks[0, 0] += 1j * scale_stack(gamma_00.copy(), self.left_occupancies)
+        sse_x.blocks[-1, -1] += 1j * scale_stack(
+            gamma_nn.copy(), self.right_occupancies
+        )
+
+    def _assemble_system_matrix(self, sse_retarded: DSBSparse) -> None:
+        """Assembles the system matrix.
+
+        Parameters
+        ----------
+        sse_retarded : DSBSparse
+            The retarded scattering self-energy.
+
+        """
+        self.system_matrix.data = self.bare_system_matrix.data
+        self.system_matrix -= sse_retarded
+
+    def _stash_contact_blocks_x(
+        self,
+        sse_x: DSBSparse,
+        sse_retarded: DSBSparse,
+    ):
+        """Stashes the contact OBC blocks.
+
+        Parameters
+        ----------
+        sse_x : DSBSparse
+            The combined lesser and greater self-energy.
+        sse_retarded : DSBSparse
+            The retarded self-energy.
+
+        """
+        self.obc_blocks_retarded_left[:] = sse_retarded.blocks[0, 0]
+        self.obc_blocks_retarded_right[:] = sse_retarded.blocks[-1, -1]
+        self.obc_blocks_x_left[:] = sse_x.blocks[0, 0]
+        self.obc_blocks_x_right[:] = sse_x.blocks[-1, -1]
+
+    def _compute_contact_current_x(
+        self, sse_x: DSBSparse, g_: tuple[DSBSparse, ...]
+    ) -> None:
+        """Computes the contact current.
+
+        Parameters
+        ----------
+        sse_x : DSBSparse
+            The combined lesser and greater self-energy.
+        g_ : tuple[DSBSparse, ...]
+            The Green's function tuple. In the order (lesser, greater,
+            retarded).
+        """
+        g_x, __ = g_
+
+        nel = len(self.energies_lesser)
+        noe = self.number_of_overlap_energies
+
+        self.i_left = xp.zeros_like(self.energies, dtype=xp.complex128)
+        i_left = xp.trace(
+            (sse_x.blocks[0, 0] - self.obc_blocks_x_left)[nel : nel + noe]
+            @ g_x.blocks[0, 0][nel - noe : nel]
+            - g_x.blocks[0, 0][nel : nel + noe]
+            @ (sse_x.blocks[0, 0] - self.obc_blocks_x_left)[nel - noe : nel],
+            axis1=-2,
+            axis2=-1,
+        )
+        self.i_left[nel - noe : nel] = i_left
+        self.i_right = xp.zeros_like(self.energies, dtype=xp.complex128)
+        i_right = xp.trace(
+            (sse_x.blocks[-1, -1] - self.obc_blocks_x_right)[nel : nel + noe]
+            @ g_x.blocks[-1, -1][nel - noe : nel]
+            - g_x.blocks[-1, -1][nel : nel + noe]
+            @ (sse_x.blocks[-1, -1] - self.obc_blocks_x_right)[nel - noe : nel],
+            axis1=-2,
+            axis2=-1,
+        )
+        self.i_right[nel - noe : nel] = i_right
+
+    def _filter_peaks(self, out: tuple[DSBSparse, ...]) -> None:
+        """Filters out peaks in the Green's functions.
+
+        Parameters
+        ----------
+        out : tuple[DSBSparse, ...]
+            The Green's function tuple. In the order (lesser, greater,
+        """
+
+        # NOTE: This filtering only works in flatband systems.
+        # Otherwise, the dos and charge densities should be summed per
+        # transport cell (in the old code the trace is taken during
+        # RGF).
+        # TODO: make parameters settable.
+        if self.flatband:
+            g_x, g_retarded = out
+            nel = len(self.energies_lesser)
+            noe = self.number_of_overlap_energies
+            dos = xp.zeros_like(self.energies)
+            dos_x = -g_retarded.diagonal().imag.sum(1)
+            dos[:nel] = dos_x[:nel]
+            dos[nel:] = dos_x[nel + noe :]
+            ne = g_x.diagonal().imag.sum(1)[:nel]
+            nh = -g_x.diagonal().imag.sum(1)[nel:]
+            charge = xp.zeros_like(self.energies)
+            charge[:nel] = ne
+            charge[nel - noe :] += nh
+            f1 = xp.abs(dos - charge) / (xp.abs(dos) + 1e-6)
+            f2 = xp.abs(dos - charge) / (xp.abs(charge) + 1e-6)
+
+            # peaks = find_peaks(xp.abs(dos), height=0.5)[0]
+            # # TODO: Should communicate boundary energies to correctly filter
+            # # makes arrays of bools
+            # f3 = xp.zeros_like(f1, dtype=bool)
+            # f3[peaks] = True
+
+            mask = (f1 > 1e-1) | (f2 > 1e-1) | (dos < 0)
+
+            assert g_x.distribution_state == "stack"
+            g_x.data[:nel][mask[:nel]] = 0.0
+            g_x.data[nel:][mask[nel - noe :]] = 0.0
+            g_retarded.data[:nel][mask[:nel]] = 0.0
+            g_retarded.data[nel:][mask[nel - noe :]] = 0.0
+
+    def _recover_contact_blocks_x(self, sse_x: DSBSparse, sse_retarded: DSBSparse):
+        """Recovers the stashed contact OBC blocks.
+
+        Parameters
+        ----------
+        sse_x : DSBSparse
+            The combined lesser and greater self-energy.
+        sse_retarded : DSBSparse
+            The retarded self-energy.
+        """
+        sse_retarded.blocks[0, 0] = self.obc_blocks_retarded_left[:]
+        sse_retarded.blocks[-1, -1] = self.obc_blocks_retarded_right[:]
+        sse_x.blocks[0, 0] = self.obc_blocks_x_left[:]
+        sse_x.blocks[-1, -1] = self.obc_blocks_x_right[:]
+
+    def solve(
+        self,
+        sse_x: DSBSparse,
+        sse_stupid: DSBSparse,
+        sse_retarded: DSBSparse,
+        out: tuple[DSBSparse, ...],
+    ):
+        """Solves for the electron Green's function.
+
+        Parameters
+        ----------
+        sse_x : DSBSparse
+            The combined lesser and greater self-energy.
+        sse_retarded : DSBSparse
+            The retarded self-energy.
+        out : tuple[DSBSparse, ...]
+            The output matrices. The order is (x, retarded).
+        """
+        times = []
+        self._stash_contact_blocks_x(sse_x, sse_retarded)
+
+        times.append(time.perf_counter())
+        self._assemble_system_matrix(sse_retarded)
+        t_assemble = time.perf_counter() - times.pop()
+
+        if self.band_edge_tracking == "eigenvalues":
+            e_0_left, e_0_right = find_renormalized_eigenvalues(
+                self.hamiltonian_sparray,
+                self.overlap_sparray,
+                self.potential,
+                sse_retarded,
+                self.energies,
+                (
+                    self.left_fermi_level + self.delta_fermi_level_conduction_band,
+                    self.right_fermi_level + self.delta_fermi_level_conduction_band,
+                ),
+                (self.left_mid_gap_energy, self.right_mid_gap_energy),
+            )
+            self._update_fermi_levels(e_0_left, e_0_right)
+
+        times.append(time.perf_counter())
+        self._apply_obc_x(sse_x, sse_retarded)
+        t_obc = time.perf_counter() - times.pop()
+
+        times.append(time.perf_counter())
+        # TODO: Implement selected_solve_x
+        # self.solver.selected_solve_x(
+        #     a=self.system_matrix,
+        #     sigma_x=sse_x,
+        #     out=out,
+        #     return_retarded=True,
+        # )
+        self.solver.selected_solve(
+            a=self.system_matrix,
+            sigma_lesser=sse_x,
+            sigma_greater=sse_x,
+            out=(out[0], out[0], out[1]),
+            return_retarded=True,
+        )
+        t_solve = time.perf_counter() - times.pop()
+
+        self._compute_contact_current_x(sse_x, out)
+        self._recover_contact_blocks_x(sse_x, sse_retarded)
+
+        # anti symmetrize
+        g_x, g_retarded = out
+        g_x.data = 0.5 * (g_x.data - g_x.ltranspose(copy=True).data.conj())
 
         self._filter_peaks(out)
 

--- a/src/quatrex/electron/sse_coulomb_screening.py
+++ b/src/quatrex/electron/sse_coulomb_screening.py
@@ -307,11 +307,15 @@ class SigmaCoulombScreening_X(ScatteringSelfEnergy):
             m.dtranspose() if m.distribution_state != "nnz" else None
 
         # Compute the full self-energy using the convolution theorem.
-        sigma_x.data[:nel] += self.prefactor * (
-            fft_convolve(g_x.data[:nel], self.w_lesser_reduced.data)[:nel]
+        sigma_x._data[:nel] += self.prefactor * (
+            fft_convolve(g_x.data[:nel], self.w_lesser_reduced.data)[
+                -nel - noe + 1 : -noe + 1
+            ]
         )
-        sigma_x.data[nel:] += self.prefactor * (
-            -fft_correlate(g_x.data[nel:], self.w_lesser_reduced.data.conj())[-neg:]
+        sigma_x._data[nel:] += self.prefactor * (
+            -fft_correlate(g_x.data[nel:], self.w_lesser_reduced.data.conj())[
+                noe - 1 : neg + noe - 1
+            ]
         )
 
         # Compute retarded self-energy with a Hilbert transform.
@@ -321,10 +325,10 @@ class SigmaCoulombScreening_X(ScatteringSelfEnergy):
         sigma_antihermitian[nel - noe :] = 1j * xp.imag(sigma_x.data[nel:])
         sigma_antihermitian[:nel] -= 1j * xp.imag(sigma_x.data[:nel])
         sigma_hermitian = hilbert_transform(sigma_antihermitian, self.energies)
-        sigma_retarded.data[:nel] += (
+        sigma_retarded._data[:nel] += (
             1j * sigma_hermitian[:nel] + sigma_antihermitian[:nel] / 2
         )
-        sigma_retarded.data[nel:] += (
+        sigma_retarded._data[nel:] += (
             1j * sigma_hermitian[nel - noe :] + sigma_antihermitian[nel - noe :] / 2
         )
 

--- a/src/quatrex/electron/sse_coulomb_screening.py
+++ b/src/quatrex/electron/sse_coulomb_screening.py
@@ -220,6 +220,124 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             m.dtranspose() if m.distribution_state != "stack" else None
 
 
+class SigmaCoulombScreening_X(ScatteringSelfEnergy):
+    """Computes the scattering self-energy from the Coulomb screening.
+
+    Parameters
+    ----------
+    quatrex_config : QuatrexConfig
+        The Quatrex configuration.
+    compute_config : ComputeConfig
+        The compute configuration.
+    electron_energies : NDArray
+        The energies for the electron system.
+
+    """
+
+    def __init__(
+        self,
+        quatrex_config: QuatrexConfig,
+        compute_config: ComputeConfig,
+        energies: NDArray,
+        energies_x: NDArray,
+        number_of_energies_lesser: int,
+        number_of_overlap_energies: int,
+        sparsity_pattern: sparse.coo_matrix,
+    ):
+        """Initializes the scattering self-energy."""
+        self.energies = energies
+        self.prefactor = 1j / (2 * xp.pi) * (energies_x[1] - energies_x[0])
+        self.nel = number_of_energies_lesser
+        self.neg = len(energies_x) - number_of_energies_lesser
+        self.noe = number_of_overlap_energies
+        block_sizes = distributed_load(quatrex_config.input_dir / "block_sizes.npy")
+        # TODO: This is pretty wasteful memory-wise.
+        self.w_lesser_reduced = compute_config.dsbsparse_type.from_sparray(
+            sparsity_pattern.astype(xp.complex128),
+            block_sizes=block_sizes,
+            global_stack_shape=energies_x.shape,
+            densify_blocks=[(0, 0), (-1, -1)],  # Densify for OBC.
+        )
+
+    def compute(
+        self,
+        g_x: DSBSparse,
+        w_lesser: DSBSparse,
+        out: tuple[DSBSparse, ...],
+    ) -> None:
+        """Computes the GW self-energy.
+
+        Parameters
+        ----------
+        g_x : DSBSparse
+            The combines lesser/greater Green's function.
+        w_x : DSBSparse
+            The greater screened Coulomb interaction.
+        out : tuple[DSBSparse, ...]
+            The output matrices for the self-energy. The order is
+            sigma_x, sigma_retarded.
+
+        """
+        nel = self.nel
+        neg = self.neg
+        noe = self.noe
+        # If the w_x don't have the same sparsity
+        # pattern as g_x, we have to reduce them to
+        # the same sparsity pattern.
+        if w_lesser.nnz != self.w_lesser_reduced.nnz:
+            num_blocks = len(self.w_lesser_reduced.block_sizes)
+            original_block_sizes = w_lesser.block_sizes
+            w_lesser.block_sizes = self.w_lesser_reduced.block_sizes
+            for i in range(num_blocks):
+                for j in range(max(0, i - 1), min(num_blocks, i + 2)):
+                    self.w_lesser_reduced.blocks[i, j] = w_lesser.blocks[i, j]
+
+            w_lesser.block_sizes = original_block_sizes
+        else:
+            self.w_lesser_reduced.data = w_lesser.data
+
+        sigma_x, sigma_retarded = out
+        # Transpose the matrices to nnz distribution.
+        for m in (
+            g_x,
+            self.w_lesser_reduced,
+            sigma_x,
+            sigma_retarded,
+        ):
+            m.dtranspose() if m.distribution_state != "nnz" else None
+
+        # Compute the full self-energy using the convolution theorem.
+        sigma_x.data[:nel] += self.prefactor * (
+            fft_convolve(g_x.data[:nel], self.w_lesser_reduced.data)[:nel]
+        )
+        sigma_x.data[nel:] += self.prefactor * (
+            -fft_correlate(g_x.data[nel:], self.w_lesser_reduced.data.conj())[-neg:]
+        )
+
+        # Compute retarded self-energy with a Hilbert transform.
+        sigma_antihermitian = xp.zeros(
+            (len(self.energies), sigma_retarded.data.shape[-1]), dtype=xp.complex128
+        )
+        sigma_antihermitian[nel - noe :] = 1j * xp.imag(sigma_x.data[nel:])
+        sigma_antihermitian[:nel] -= 1j * xp.imag(sigma_x.data[:nel])
+        sigma_hermitian = hilbert_transform(sigma_antihermitian, self.energies)
+        sigma_retarded.data[:nel] += (
+            1j * sigma_hermitian[:nel] + sigma_antihermitian[:nel] / 2
+        )
+        sigma_retarded.data[nel:] += (
+            1j * sigma_hermitian[nel - noe :] + sigma_antihermitian[nel - noe :] / 2
+        )
+
+        # Transpose the matrices to stack distribution.
+        for m in (
+            g_x,
+            self.w_lesser_reduced,
+            sigma_x,
+            sigma_retarded,
+        ):
+            m.dtranspose() if m.distribution_state != "stack" else None
+
+
 class SigmaFock(ScatteringSelfEnergy):
     """Computes the bare Fock self-energy.
 
@@ -282,4 +400,74 @@ class SigmaFock(ScatteringSelfEnergy):
         gl_density = self.prefactor * g_lesser.data.sum(axis=0)
         sigma_retarded.data += xp.real(gl_density * self.coulomb_matrix.data)
         for m in (g_lesser, sigma_retarded, self.coulomb_matrix):
+            m.dtranspose() if m.distribution_state != "stack" else None
+
+
+class SigmaFock_X(ScatteringSelfEnergy):
+    """Computes the bare Fock self-energy.
+
+    Parameters
+    ----------
+    quatrex_config : QuatrexConfig
+        The Quatrex configuration.
+    compute_config : ComputeConfig
+        The compute configuration.
+    electron_energies : NDArray
+        The energies for the electron system.
+
+    """
+
+    def __init__(
+        self,
+        quatrex_config: QuatrexConfig,
+        compute_config: ComputeConfig,
+        number_of_energies_lesser: int,
+        electron_energies: NDArray,
+        sparsity_pattern: sparse.coo_matrix,
+    ):
+        """Initializes the bare Fock self-energy."""
+        self.nel = number_of_energies_lesser
+        self.energies = electron_energies
+        self.prefactor = 1j / (2 * xp.pi) * (self.energies[1] - self.energies[0])
+        coulomb_matrix_sparray = distributed_load(
+            quatrex_config.input_dir / "coulomb_matrix.npz"
+        ).astype(xp.complex128)
+        # Load block sizes for the coulomb matrix.
+        block_sizes = distributed_load(quatrex_config.input_dir / "block_sizes.npy")
+
+        # Create the DSBSparse object.
+        # TODO: This is pretty wasteful memory-wise.
+        self.coulomb_matrix = compute_config.dsbsparse_type.from_sparray(
+            sparsity_pattern.astype(xp.complex128),
+            block_sizes=block_sizes,
+            global_stack_shape=self.energies.shape,
+            densify_blocks=[(0, 0), (-1, -1)],  # Densify for OBC.
+        )
+        self.coulomb_matrix.data = 0.0
+        self.coulomb_matrix += coulomb_matrix_sparray
+
+    def compute(self, g_x: DSBSparse, out: tuple[DSBSparse, ...]) -> None:
+        """Computes the Fock self-energy.
+
+        Parameters
+        ----------
+        g_x : DSBSparse
+            The combined lesser/greater Green's function.
+        out : tuple[DSBSparse, ...]
+            The output matrices for the self-energy. The order is
+            sigma_retarded.
+
+        """
+        # TODO: Check again if we really need to transpose the matrices
+        # here.
+        nel = self.nel
+        (sigma_retarded,) = out
+        for m in (g_x, sigma_retarded, self.coulomb_matrix):
+            m.dtranspose() if m.distribution_state != "nnz" else None
+        # Compute the electron density by summing over energies.
+        gl_density = self.prefactor * g_x.data[:nel].sum(axis=0)
+        sigma_fock = xp.real(gl_density * self.coulomb_matrix.data[0])
+        sigma_retarded.data += sigma_fock
+
+        for m in (g_x, sigma_retarded, self.coulomb_matrix):
             m.dtranspose() if m.distribution_state != "stack" else None


### PR DESCRIPTION
Lesser/Greater Green's function and self-energy are computed on different energy grids. The energy grids are concatenated into the `energies_x` vector (`><` makes an `x`), where lesser energies comes first and the greater follows. Only the lesser part of the Polarization and screened interaction is computed (greater follows from symmetry). Some issues have to be resolved before it can be merged, see below.

Issues:
- [ ] Structure of the code (?)
- [ ] Improve heuristic for selecting the greater/lesser energy grids
- [ ] Create additional solver such that only one of lesser/greater is computed (see `solve` and `selected_solve` methods)
- [ ] Observables (contact current might be tricky since communication is needed, but the others are just shifting energies correctly)
- [ ] Filtering of peaks
- [ ] More stuff I've missed (?)